### PR TITLE
Collapsible sidebar

### DIFF
--- a/src/components/CollapsibleSidebar.tsx
+++ b/src/components/CollapsibleSidebar.tsx
@@ -27,6 +27,7 @@ import { Link } from "react-router-dom";
 
 export default function CollapsibleSidebar({ open }: { open: boolean }) {
 	const [clickedServer, setClickedServer] = useState("");
+	const toggle_c_sidebar = useStore((state) => state.toggle_c_sidebar);
 	const switchLeftSidebarContext = useStore(
 		(state) => state.switchLeftSidebarContext
 	);
@@ -160,6 +161,7 @@ export default function CollapsibleSidebar({ open }: { open: boolean }) {
 							<SidebarMenuButton
 								size="lg"
 								className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground h-[60px] group-data-[collapsible=icon]:[&>div:last-child]:hidden group-data-[collapsible=icon]:overflow-visible py-0 px-3 shrink-0 gap-0"
+								onClick={toggle_c_sidebar}
 							>
 								<Avatar className="relative group-data-[collapsible=icon]:rounded-full size-[60px] group-data-[collapsible=icon]:size-[55px] flex items-center justify-center bg-charcoal rounded-[15px] p-[10px] group-data-[collapsible=icon]:p-1.5 overflow-visible rounded-r-none">
 									<div className="absolute right-0.5 group-data-[collapsible=icon]:-right-1 top-1 bg-crimson rounded-full size-[14px] border-[3px] border-solid border-onyx"></div>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -523,8 +523,7 @@ const sidebarMenuButtonVariants = cva(
 	{
 		variants: {
 			variant: {
-				default:
-					"hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+				default: "hover:bg-sidebar-none hover:text-none",
 				outline:
 					"bg-white shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))] dark:bg-zinc-950",
 			},

--- a/src/hooks/base-context.tsx
+++ b/src/hooks/base-context.tsx
@@ -10,6 +10,7 @@ interface AppStateProps {
 	r_sidebar_display_context: string;
 	toggle_l_sidebar: () => void;
 	toggle_r_sidebar: () => void;
+	toggle_c_sidebar: () => void;
 	toggle_page_is_server: () => void;
 	switchLeftSidebarContext: (newAppState: string) => void;
 	switchRightSidebarContext: (newAppState: string) => void;
@@ -27,7 +28,7 @@ export const useStore = create<AppStateProps>()(
 
 			toggle_c_sidebar: () =>
 				set((state) => ({
-					l_sidebar_state: !state.l_sidebar_state,
+					c_sidebar_state: !state.c_sidebar_state,
 				})),
 			toggle_l_sidebar: () =>
 				set((state) => ({


### PR DESCRIPTION
Found bugs:
1. right sidebar might remain open on page reload, this is due to the state persistence
2. The right sidebar overflows when the route is either "messages" or "server"
3. Collapsible Sidebar Menu buttons need to have the custom hover, active and notification state 